### PR TITLE
fix(security): replace url-regex with native URL constructor (CVE-2020-7661)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "rss-parser": "^3.12.0",
-    "swr": "^0.5.6",
-    "url-regex": "^5.0.0"
+    "swr": "^0.5.6"
   },
   "devDependencies": {
     "@types/react": "17.0.18",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,15 @@
 import { useRouter } from "next/dist/client/router";
 import Head from "next/head";
 import { ChangeEvent, useState } from "react";
-import urlRegex from "url-regex";
+
+function isValidUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 export default function Home() {
   const router = useRouter();
@@ -11,7 +19,7 @@ export default function Home() {
 
   const onChangeInput = (evt: ChangeEvent<HTMLInputElement>) => {
     const value = evt.target.value;
-    const isValid = urlRegex({ exact: true }).test(text);
+    const isValid = isValidUrl(value);
 
     setText(value);
     setValidForm(isValid);


### PR DESCRIPTION
## 変更内容

`url-regex` を削除し、native `URL` constructor による URL 検証に置き換えました。

## 背景

Dependabot alert #1: **CVE-2020-7661** (url-regex, HIGH severity)
- ReDoS (Catastrophic backtracking) 脆弱性
- **修正版なし** (no fix available, permanently unfixed upstream)
- 2023年7月から open のまま

## 修正方針

`url-regex` を削除し、ブラウザネイティブの `URL` コンストラクタで代替。

```typescript
// Before (vulnerable to ReDoS)
import urlRegex from "url-regex";
const isValid = urlRegex({ exact: true }).test(text); // ← 旧 state を参照するバグも

// After (safe)
function isValidUrl(str: string): boolean {
  try {
    const url = new URL(str);
    return url.protocol === "http:" || url.protocol === "https:";
  } catch {
    return false;
  }
}
const isValid = isValidUrl(value); // ← 新 value を正しく参照
```

## 副作用

`text` (古い state) ではなく `value` (新しい入力値) を検証するよう修正し、
「バリデーションが1キー入力遅延する」バグも同時修正。

Closes dependabot alert #1